### PR TITLE
add flexibility for setting positive and negative button name and string modify.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,10 +47,7 @@ Super Lite Android Library to select files/directories from Device Storage.
         properties.extensions=null;
     ```
 
-3. Next create an instance of `FilePickerDialog`, and pass `Context` and `DialogProperties` references as parameters. Optional:
-* You can change the title of dialog. Default is current directory name.
-* Set positive button string. Default is Select.
-* Set negative button string. Defalut is Cancel.
+3. Next create an instance of `FilePickerDialog`, and pass `Context` and `DialogProperties` references as parameters. Optional: You can change the title of dialog. Default is current directory name. Set the positive button string. Default is Select. Set the negative button string. Defalut is Cancel.
 
     ```java
         FilePickerDialog dialog = new FilePickerDialog(MainActivity.this,properties);

--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ Super Lite Android Library to select files/directories from Device Storage.
         properties.selection_type=DialogConfigs.FILE_SELECT;
         properties.root=new File(DialogConfigs.DEFAULT_DIR);
         properties.error_dir=new File(DialogConfigs.DEFAULT_DIR);
-        properties.offset_dir=new File(DialogConfigs.DEFAULT_DIR);
+        properties.offset=new File(DialogConfigs.DEFAULT_DIR);
         properties.extensions=null;
     ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -47,11 +47,16 @@ Super Lite Android Library to select files/directories from Device Storage.
         properties.extensions=null;
     ```
 
-3. Next create an instance of `FilePickerDialog`, and pass `Context` and `DialogProperties` references as parameters. Optional: You can change the title of dialog. Default is current directory name.
+3. Next create an instance of `FilePickerDialog`, and pass `Context` and `DialogProperties` references as parameters. Optional:
+* You can change the title of dialog. Default is current directory name.
+* Set positive button string. Default is Select.
+* Set negative button string. Defalut is Cancel.
 
     ```java
         FilePickerDialog dialog = new FilePickerDialog(MainActivity.this,properties);
         dialog.setTitle("Select a File");
+        dialog.setPositiveBtnName("Select");
+        dialog.setNegativeBtnName("Cancel");
     ```
 
 4.  Next, Attach `DialogSelectionListener` to `FilePickerDialog` as below,

--- a/app/src/main/java/com/github/angads25/filepickerdemo/MainActivity.java
+++ b/app/src/main/java/com/github/angads25/filepickerdemo/MainActivity.java
@@ -60,6 +60,8 @@ public class MainActivity extends AppCompatActivity
         //Instantiate FilePickerDialog with Context and DialogProperties.
         dialog=new FilePickerDialog(MainActivity.this,properties);
         dialog.setTitle("Select a File");
+        dialog.setPositiveBtnName("Select");
+        dialog.setNegativeBtnName("Cancel");
         RadioGroup modeRadio=(RadioGroup)findViewById(R.id.modeRadio);
         modeRadio.check(R.id.singleRadio);
         modeRadio.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {

--- a/filepicker/src/main/AndroidManifest.xml
+++ b/filepicker/src/main/AndroidManifest.xml
@@ -7,6 +7,5 @@
 
     <application
         android:allowBackup="true"
-        android:label="@string/app_name"
         android:supportsRtl="true"/>
 </manifest>

--- a/filepicker/src/main/java/com/github/angads25/filepicker/controller/adapters/FileListAdapter.java
+++ b/filepicker/src/main/java/com/github/angads25/filepicker/controller/adapters/FileListAdapter.java
@@ -137,7 +137,7 @@ public class FileListAdapter extends BaseAdapter{
             holder.type.setText(R.string.label_parent_directory);
         }
         else {
-            holder.type.setText("Last edited: " + sdate.format(date) + ", " + stime.format(date));
+            holder.type.setText(context.getString(R.string.last_edit) + sdate.format(date) + ", " + stime.format(date));
         }
         if(holder.fmark.getVisibility()==View.VISIBLE) {
             if(i==0&&item.getFilename().startsWith("..."))

--- a/filepicker/src/main/java/com/github/angads25/filepicker/view/FilePickerDialog.java
+++ b/filepicker/src/main/java/com/github/angads25/filepicker/view/FilePickerDialog.java
@@ -63,6 +63,8 @@ public class FilePickerDialog extends Dialog implements AdapterView.OnItemClickL
     private FileListAdapter mFileListAdapter;
     private Button select;
     private String titleStr=null;
+    private String positiveBtnNameStr=null;
+    private String negativeBtnNameStr=null;
 
     public static final int EXTERNAL_READ_PERMISSION_GRANT=112;
 
@@ -93,6 +95,9 @@ public class FilePickerDialog extends Dialog implements AdapterView.OnItemClickL
         title=(TextView)findViewById(R.id.title);
         dir_path=(TextView)findViewById(R.id.dir_path);
         Button cancel = (Button) findViewById(R.id.cancel);
+        if(negativeBtnNameStr!=null) {
+            cancel.setText(negativeBtnNameStr);
+        }
         select.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -120,12 +125,14 @@ public class FilePickerDialog extends Dialog implements AdapterView.OnItemClickL
                 /*  Handler function, called when a checkbox is checked ie. a file is
                  *  selected.
                  */
+                positiveBtnNameStr = positiveBtnNameStr==null ?
+                        context.getResources().getString(R.string.choose_button_label) : positiveBtnNameStr;
                 int size=MarkedItemList.getFileCount();
                 if(size==0)
-                {   select.setText(context.getResources().getString(R.string.choose_button_label));
+                {   select.setText(positiveBtnNameStr);
                 }
                 else
-                {   String button_label=context.getResources().getString(R.string.choose_button_label)+" ("+size+") ";
+                {   String button_label=positiveBtnNameStr+" ("+size+") ";
                     select.setText(button_label);
                 }
                 if(properties.selection_mode==DialogConfigs.SINGLE_MODE)
@@ -167,7 +174,9 @@ public class FilePickerDialog extends Dialog implements AdapterView.OnItemClickL
     @Override
     protected void onStart() {
         super.onStart();
-        select.setText(context.getResources().getString(R.string.choose_button_label));
+        positiveBtnNameStr = positiveBtnNameStr==null ?
+                context.getResources().getString(R.string.choose_button_label) : positiveBtnNameStr;
+        select.setText(positiveBtnNameStr);
         if(Utility.checkStorageAccessPermissions(context))
         {   File currLoc;
             internalList.clear();
@@ -251,6 +260,26 @@ public class FilePickerDialog extends Dialog implements AdapterView.OnItemClickL
         {   this.titleStr=null;
         }
         setTitle();
+    }
+
+    public void setPositiveBtnName(CharSequence positiveBtnNameStr)
+    {
+        if(positiveBtnNameStr!=null) {
+            this.positiveBtnNameStr = positiveBtnNameStr.toString();
+        }
+        else
+        {   this.positiveBtnNameStr=null;
+        }
+    }
+
+    public void setNegativeBtnName(CharSequence negativeBtnNameStr)
+    {
+        if(negativeBtnNameStr!=null) {
+            this.negativeBtnNameStr = negativeBtnNameStr.toString();
+        }
+        else
+        {   this.negativeBtnNameStr=null;
+        }
     }
 
     public void markFiles(List<String> paths)
@@ -354,12 +383,15 @@ public class FilePickerDialog extends Dialog implements AdapterView.OnItemClickL
         }
         else
         {   super.show();
+            positiveBtnNameStr = positiveBtnNameStr==null ?
+                    context.getResources().getString(R.string.choose_button_label) : positiveBtnNameStr;
+            select.setText(positiveBtnNameStr);
             int size=MarkedItemList.getFileCount();
             if(size==0)
-            {   select.setText(context.getResources().getString(R.string.choose_button_label));
+            {   select.setText(positiveBtnNameStr);
             }
             else
-            {   String button_label=context.getResources().getString(R.string.choose_button_label)+" ("+size+") ";
+            {   String button_label=positiveBtnNameStr+" ("+size+") ";
                 select.setText(button_label);
             }
         }

--- a/filepicker/src/main/res/values-de/strings.xml
+++ b/filepicker/src/main/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-   <string name="app_name">Dateiauswahl</string>
    <string name="cancel_button_label">Abbrechen</string>
    <string name="choose_button_label">Auswählen</string>
    <string name="label_parent_directory">Verzeichnis hoch</string>

--- a/filepicker/src/main/res/values-fr/strings.xml
+++ b/filepicker/src/main/res/values-fr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-   <string name="app_name">Gestionnaire de fichiers</string>
    <string name="cancel_button_label">Annuler</string>
    <string name="choose_button_label">Choisir</string>
    <string name="label_parent_directory">Répertoire parent</string>

--- a/filepicker/src/main/res/values-zh-rTW/strings.xml
+++ b/filepicker/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+   <string name="cancel_button_label">取消</string>
+   <string name="choose_button_label">選擇</string>
+   <string name="label_parent_directory">上層資料夾</string>
+   <string name="last_edit">最後修改：</string>
+</resources>

--- a/filepicker/src/main/res/values/strings.xml
+++ b/filepicker/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
    <string name="choose_button_label">Select</string>
    <string name="default_dir" translatable="false">/sdcard</string>
    <string name="label_parent_directory">Parent Directory</string>
+   <string name="last_edit">Last edited: </string>
 </resources>

--- a/filepicker/src/main/res/values/strings.xml
+++ b/filepicker/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-   <string name="app_name">FilePicker</string>
    <string name="cancel_button_label">Cancel</string>
    <string name="choose_button_label">Select</string>
    <string name="default_dir" translatable="false">/sdcard</string>


### PR DESCRIPTION
Hi,

In this PR, I have modified the code in the following list.

1. add two functions:

`
public void setPositiveBtnName(CharSequence positiveBtnNameStr)
`
`
public void setNegativeBtnName(CharSequence negativeBtnNameStr)
`
Instead of using fixed string in library, it can allow user to specify the string of button.

2. Add a new string last_edit to make it more flexible.

3. Add traditional chinese string.xml

4. Remove app_name string, This will override the same string in user's app.

5. fix typo in readme, offset_dir -> offset. Dialog Properties do not have offset_dir.

I think this will help this lib be more elegant. Hope you can merge it.
Thanks.