### PR TITLE
calling cancel instead of dissmiss make setOnCancelListener works

### DIFF
--- a/filepicker/src/main/java/com/github/angads25/filepicker/view/FilePickerDialog.java
+++ b/filepicker/src/main/java/com/github/angads25/filepicker/view/FilePickerDialog.java
@@ -136,7 +136,7 @@ public class FilePickerDialog extends Dialog implements AdapterView.OnItemClickL
         cancel.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                dismiss();
+                cancel();
             }
         });
         mFileListAdapter = new FileListAdapter(internalList, context, properties);


### PR DESCRIPTION
fix to issue #61 https://github.com/Angads25/android-filepicker/issues/61