### PR TITLE
feature - limit maximum # of selections using DialogProperties

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -157,33 +157,33 @@ eg. /sdcard:/mnt:
 
 #### Theme.Black
 
-![Screenshot 1](https://raw.githubusercontent.com/Angads25/android-filepicker/master/screenshots/theme_black.png)
+![Screenshot 1](https://raw.githubusercontent.com/Angads25/android-filepicker/release/screenshots/theme_black.png)
 
 #### Theme.Holo
 
-![Screenshot 2](https://raw.githubusercontent.com/Angads25/android-filepicker/master/screenshots/theme_holo.png)
+![Screenshot 2](https://raw.githubusercontent.com/Angads25/android-filepicker/release/screenshots/theme_holo.png)
 
 #### Theme.Holo.Light
 
-![Screenshot 3](https://raw.githubusercontent.com/Angads25/android-filepicker/master/screenshots/theme_holo_light.png)
+![Screenshot 3](https://raw.githubusercontent.com/Angads25/android-filepicker/release/screenshots/theme_holo_light.png)
 
 #### Theme.Material
 
-![Screenshot 4](https://raw.githubusercontent.com/Angads25/android-filepicker/master/screenshots/theme_material.png)
+![Screenshot 4](https://raw.githubusercontent.com/Angads25/android-filepicker/release/screenshots/theme_material.png)
 
 #### Theme.DeviceDefault
 
-![Screenshot 5](https://raw.githubusercontent.com/Angads25/android-filepicker/master/screenshots/theme_device_default.png)
+![Screenshot 5](https://raw.githubusercontent.com/Angads25/android-filepicker/release/screenshots/theme_device_default.png)
 
 ### Performance
 
 #### GPU Overdraw
 
-![Performance 1](https://raw.githubusercontent.com/Angads25/android-filepicker/master/screenshots/performance_overdraw.png)
+![Performance 1](https://raw.githubusercontent.com/Angads25/android-filepicker/release/screenshots/performance_overdraw.png)
 
 #### GPU Rendering
 
-![Performance 2](https://raw.githubusercontent.com/Angads25/android-filepicker/master/screenshots/profile_gpu_rendering.png)
+![Performance 2](https://raw.githubusercontent.com/Angads25/android-filepicker/release/screenshots/profile_gpu_rendering.png)
 
 ### License
     Copyright (C) 2016 Angad Singh

--- a/filepicker/src/main/java/com/github/angads25/filepicker/controller/adapters/FileListAdapter.java
+++ b/filepicker/src/main/java/com/github/angads25/filepicker/controller/adapters/FileListAdapter.java
@@ -155,19 +155,29 @@ public class FileListAdapter extends BaseAdapter{
         holder.fmark.setOnCheckedChangedListener(new OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(MaterialCheckbox checkbox, boolean isChecked) {
-                item.setMarked(isChecked);
-                if (item.isMarked()) {
-                    if(properties.selection_mode == DialogConfigs.MULTI_MODE) {
-                        MarkedItemList.addSelectedItem(item);
+                if(properties.selection_mode == DialogConfigs.MULTI_MODE) {
+                    if(isChecked){
+                        if(MarkedItemList.getFileCount() < properties.max_selections){
+                            item.setMarked(isChecked);
+                            MarkedItemList.addSelectedItem(item);
+                        }else{
+                            holder.fmark.setChecked(false);
+                        }
                     }
-                    else {
+                    else{
+                        item.setMarked(isChecked); //setMarked(false)
+                        MarkedItemList.removeSelectedItem(item.getLocation());
+                    }
+                } else{  //SINGLE_MODE
+                    item.setMarked(isChecked);
+                    if (item.isMarked()) {
                         MarkedItemList.addSingleFile(item);
+                    } else {
+                        MarkedItemList.removeSelectedItem(item.getLocation());
                     }
-                }
-                else {
-                    MarkedItemList.removeSelectedItem(item.getLocation());
                 }
                 notifyItemChecked.notifyCheckBoxIsClicked();
+
             }
         });
         return view;

--- a/filepicker/src/main/java/com/github/angads25/filepicker/model/DialogProperties.java
+++ b/filepicker/src/main/java/com/github/angads25/filepicker/model/DialogProperties.java
@@ -74,6 +74,11 @@ public class DialogProperties {
      */
     public String[] extensions;
 
+    /** Max Selections limits the maximum number of selections when in MULTI_MODE
+     *
+     */
+    public int max_selections;
+
     public DialogProperties() {
         selection_mode = DialogConfigs.SINGLE_MODE;
         selection_type = DialogConfigs.FILE_SELECT;
@@ -81,5 +86,6 @@ public class DialogProperties {
         error_dir = new File(DialogConfigs.DEFAULT_DIR);
         offset = new File(DialogConfigs.DEFAULT_DIR);
         extensions = null;
+        max_selections = 1;
     }
 }


### PR DESCRIPTION
This feature should resolve #58.
Use properties.max_selections to limit the number of selections a user can have selected(checked).

